### PR TITLE
feat: removed a check where msg.sender needs to match the renter

### DIFF
--- a/contracts/metahub/Metahub.sol
+++ b/contracts/metahub/Metahub.sol
@@ -323,9 +323,6 @@ contract Metahub is IMetahub, Initializable, UUPSUpgradeable, AccessControlledUp
      * @inheritdoc IRentingManager
      */
     function rent(Rentings.Params calldata rentingParams, uint256 maxPaymentAmount) external returns (uint256) {
-        // Currently payer must match the renter address since the estimation might be renter specific.
-        if (_msgSender() != rentingParams.renter) revert CallerIsNotRenter();
-
         // Validate renting parameters.
         Rentings.validateRentingParams(rentingParams, _protocolConfig, _listingRegistry, _warperRegistry);
 

--- a/test/unit/metahub/renting-manager/renting-manager.behaviour.ts
+++ b/test/unit/metahub/renting-manager/renting-manager.behaviour.ts
@@ -632,37 +632,6 @@ export function shouldBehaveLikeRentingManager(): void {
         await paymentToken.connect(stranger).approve(rentingManager.address, maxPaymentAmount);
       });
 
-      context('When msg.sender is not the renter', () => {
-        beforeEach(async () => {
-          await paymentToken.mint(stranger.address, maxPaymentAmount);
-          await paymentToken.connect(stranger).approve(rentingManager.address, maxPaymentAmount);
-
-          warperAddress = await assetListerHelper.setupWarper(originalAsset, universeId, warperRegistrationParams);
-          listingId = await assetListerHelper.listAsset(
-            nftCreator,
-            originalAsset,
-            maxLockPeriod,
-            baseRate,
-            tokenId,
-            false,
-          );
-        });
-
-        it('reverts', async () => {
-          const rentalParams = {
-            listingId: listingId,
-            paymentToken: paymentToken.address,
-            rentalPeriod: 1000,
-            renter: nftCreator.address,
-            warper: warperAddress,
-          };
-
-          await expect(rentingManager.connect(stranger).rent(rentalParams, maxPaymentAmount)).to.be.revertedWith(
-            'CallerIsNotRenter()',
-          );
-        });
-      });
-
       context('When invalid rental params', () => {
         context('When base token does not match renting params', () => {
           let anotherToken: ERC20Mock;


### PR DESCRIPTION
this allows for external contracts to call the rent operation on metahub
to rent on someone else behalf.